### PR TITLE
Use `num_traits::Float` to abstract over f32/f64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num-traits = "0.2.17"
 once_cell = "1.19.0"
 pest = "2.7.5"
 pest_derive = "2.7.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vector-expr"
 authors = ["Duncan Fairbanks <duncan.fairbanks@foresightmining.com>"]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Vectorized expression parser and evaluator"
 license = "MIT OR Apache-2.0"

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,28 +1,28 @@
 /// Top-level parseable calculation.
 #[derive(Clone, Debug)]
-pub enum Expression {
-    Boolean(BoolExpression),
-    Real(RealExpression),
+pub enum Expression<Real> {
+    Boolean(BoolExpression<Real>),
+    Real(RealExpression<Real>),
     String(StringExpression),
 }
 
 /// A `bool`-valued expression.
 #[derive(Clone, Debug)]
-pub enum BoolExpression {
+pub enum BoolExpression<Real> {
     // Binary logic.
-    And(Box<BoolExpression>, Box<BoolExpression>),
-    Or(Box<BoolExpression>, Box<BoolExpression>),
+    And(Box<BoolExpression<Real>>, Box<BoolExpression<Real>>),
+    Or(Box<BoolExpression<Real>>, Box<BoolExpression<Real>>),
 
     // Unary logic.
-    Not(Box<BoolExpression>),
+    Not(Box<BoolExpression<Real>>),
 
     // Real comparisons.
-    Equal(Box<RealExpression>, Box<RealExpression>),
-    Greater(Box<RealExpression>, Box<RealExpression>),
-    GreaterEqual(Box<RealExpression>, Box<RealExpression>),
-    Less(Box<RealExpression>, Box<RealExpression>),
-    LessEqual(Box<RealExpression>, Box<RealExpression>),
-    NotEqual(Box<RealExpression>, Box<RealExpression>),
+    Equal(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
+    Greater(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
+    GreaterEqual(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
+    Less(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
+    LessEqual(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
+    NotEqual(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
 
     // String comparisons.
     StrEqual(StringExpression, StringExpression),
@@ -31,19 +31,19 @@ pub enum BoolExpression {
 
 /// An `f64`-valued expression.
 #[derive(Clone, Debug)]
-pub enum RealExpression {
+pub enum RealExpression<Real> {
     // Binary real ops.
-    Add(Box<RealExpression>, Box<RealExpression>),
-    Div(Box<RealExpression>, Box<RealExpression>),
-    Mul(Box<RealExpression>, Box<RealExpression>),
-    Pow(Box<RealExpression>, Box<RealExpression>),
-    Sub(Box<RealExpression>, Box<RealExpression>),
+    Add(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
+    Div(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
+    Mul(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
+    Pow(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
+    Sub(Box<RealExpression<Real>>, Box<RealExpression<Real>>),
 
     // Unary real ops.
-    Neg(Box<RealExpression>),
+    Neg(Box<RealExpression<Real>>),
 
     // Constant.
-    Literal(f64),
+    Literal(Real),
 
     // Input variable.
     Binding(BindingId),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,10 @@ pub fn empty_binding_map(_var_name: &str) -> BindingId {
     panic!("Empty binding map")
 }
 
+pub trait FloatExt: num_traits::Float + std::str::FromStr + Send + Sync {}
+impl FloatExt for f32 {}
+impl FloatExt for f64 {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -84,17 +88,17 @@ mod tests {
     fn real_op_precedence() {
         let mut registers = Registers::new(1);
 
-        let parsed = Expression::parse("1 * 2 + 3 * 4", empty_binding_map).unwrap();
+        let parsed = Expression::<f32>::parse("1 * 2 + 3 * 4", empty_binding_map).unwrap();
         let real = parsed.unwrap_real();
         let output = real.evaluate_without_vars(&mut registers);
         assert_eq!(&output, &[14.0]);
 
-        let parsed = Expression::parse("8 / 4 * 3", empty_binding_map).unwrap();
+        let parsed = Expression::<f32>::parse("8 / 4 * 3", empty_binding_map).unwrap();
         let real = parsed.unwrap_real();
         let output = real.evaluate_without_vars(&mut registers);
         assert_eq!(&output, &[6.0]);
 
-        let parsed = Expression::parse("4 ^ 3 ^ 2", empty_binding_map).unwrap();
+        let parsed = Expression::<f32>::parse("4 ^ 3 ^ 2", empty_binding_map).unwrap();
         let real = parsed.unwrap_real();
         let output = real.evaluate_without_vars(&mut registers);
         assert_eq!(&output, &[262144.0]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,9 +202,9 @@ mod tests {
         let real = parsed.unwrap_real();
 
         const LEN: i32 = 10_000_000;
-        let x: Vec<_> = (0..LEN).map(|i| i as f64).collect();
-        let y: Vec<_> = (0..LEN).map(|i| (LEN - i) as f64).collect();
-        let z: Vec<_> = (0..LEN).map(|i| ((LEN / 2) - i) as f64).collect();
+        let x: Vec<_> = (0..LEN).map(|i| i as f32).collect();
+        let y: Vec<_> = (0..LEN).map(|i| (LEN - i) as f32).collect();
+        let z: Vec<_> = (0..LEN).map(|i| ((LEN / 2) - i) as f32).collect();
         let bindings = &[x, y, z];
 
         let mut registers = Registers::new(LEN as usize);


### PR DESCRIPTION
It seems like there is no loss in performance, based on the `real_bench` test.